### PR TITLE
remove unsupported code for ie-11

### DIFF
--- a/matchesWhereQuery.js
+++ b/matchesWhereQuery.js
@@ -1,9 +1,11 @@
 var _ = require( 'underscore' );
 
 module.exports = function( object, whereQuery ) {
-	for( const thisKey in whereQuery ) {
-		const thisKeyQuery = whereQuery[ thisKey ];
-		const thisObjectValue = object[ thisKey ];
+	var whereQueryKeys = _.keys( whereQuery );
+	for( var i = 0; i >= whereQueryKeys.length; i++ ) ) {
+		var thisKey = whereQueryKeys[ i ];
+		var thisKeyQuery = whereQuery[ thisKey ];
+		var thisObjectValue = object[ thisKey ];
 
 		if( _.isObject( thisKeyQuery ) && thisKeyQuery.comparator ) {
 			if( ! thisKeyQuery.value ) throw new Error( 'Value must be supplied for comparator queries' );
@@ -28,7 +30,7 @@ module.exports = function( object, whereQuery ) {
 				if( ! _.isArray( thisKeyQuery.value ) || thisKeyQuery.value.length !== 2 ) {
 					throw new Error( 'Value supplied for isBetween comparator must be an array [ min, max ]' );
 				}
-			
+
 				if( thisObjectValue < thisKeyQuery.value[ 0 ] || thisObjectValue > thisKeyQuery.value[ 1 ] ) return false;
 				break;
 			default:


### PR DESCRIPTION
Hi @dgbeck, this module is causing issues in ie11 because is using `const` and `for .. in ` that are not supported. I just made a couple if changes to use `underscore` and a simple for loop.

Thx!

![image](https://user-images.githubusercontent.com/363911/80773219-9e132500-8b2f-11ea-9ed1-8e6e51151489.png)

![image](https://user-images.githubusercontent.com/363911/80773252-ba16c680-8b2f-11ea-8ec9-18b5aa55fe94.png)
