### PR TITLE
Fix contains comparator to compare by equivalence instead of reference

### DIFF
--- a/lib/matchesWhereQuery.js
+++ b/lib/matchesWhereQuery.js
@@ -1,66 +1,113 @@
 "use strict";
 
 var _underscore = _interopRequireDefault(require("underscore"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { "default": e }; }
 module.exports = function (object, whereQuery) {
-  for (var attributeName in whereQuery) {
-    var queryAttribute = whereQuery[attributeName];
-    var objectAttribute = object[attributeName];
-    if (_underscore["default"].isObject(queryAttribute) && queryAttribute.comparator) {
-      if (_underscore["default"].isUndefined(queryAttribute.value) && !['isNull', 'isNotNull'].includes(queryAttribute.comparator)) throw new Error('Value must be supplied for comparator queries');
-      switch (queryAttribute.comparator) {
-        case 'doesNotEqual':
-          if (objectAttribute === queryAttribute.value) return false;
-          break;
-        case 'isGreaterThan':
-          if (objectAttribute <= queryAttribute.value) return false;
-          break;
-        case 'isGreaterThanOrEqualTo':
-          if (objectAttribute < queryAttribute.value) return false;
-          break;
-        case 'isLessThan':
-          if (objectAttribute >= queryAttribute.value) return false;
-          break;
-        case 'isLessThanOrEqualTo':
-          if (objectAttribute > queryAttribute.value) return false;
-          break;
-        case 'isBetween':
-          if (!_underscore["default"].isArray(queryAttribute.value) || queryAttribute.value.length !== 2) {
-            throw new Error('Value supplied for isBetween comparator must be an array [ min, max ]');
-          }
-          if (objectAttribute < queryAttribute.value[0] || objectAttribute > queryAttribute.value[1]) return false;
-          break;
-        case 'startsWith':
-          if (!objectAttribute) return false;
-          // eslint-disable-next-line max-len
-          if (!_underscore["default"].isString(objectAttribute) || !_underscore["default"].isString(queryAttribute.value)) throw new Error('For startsWith comparator both the object attribute and the query value must be strings.');
-          if (!_startsWith(objectAttribute, queryAttribute.value)) return false;
-          break;
-        case 'endsWith':
-          if (!objectAttribute) return false;
-          // eslint-disable-next-line max-len
-          if (!_underscore["default"].isString(objectAttribute) || !_underscore["default"].isString(queryAttribute.value)) throw new Error('For endsWith comparator both the object attribute and the query value must be strings.');
-          if (!_endsWith(objectAttribute, queryAttribute.value)) return false;
-          break;
-        case 'isNull':
-          if (!_underscore["default"].isNull(objectAttribute)) return false;
-          break;
-        case 'isNotNull':
-          if (_underscore["default"].isNull(objectAttribute)) return false;
-          break;
-        case 'contains':
-          if (!objectAttribute) return false;
-          if (!_underscore["default"].isString(objectAttribute) && !_underscore["default"].isArray(objectAttribute)) return false;
-          if (!objectAttribute.includes(queryAttribute.value)) return false;
-          break;
-        default:
-          throw new Error('Invalid comparator ' + queryAttribute.comparator);
+  var _loop = function _loop() {
+      var queryAttribute = whereQuery[attributeName];
+      var objectAttribute = object[attributeName];
+      if (_underscore["default"].isObject(queryAttribute) && queryAttribute.comparator) {
+        if (_underscore["default"].isUndefined(queryAttribute.value) && !['isNull', 'isNotNull'].includes(queryAttribute.comparator)) throw new Error('Value must be supplied for comparator queries');
+        switch (queryAttribute.comparator) {
+          case 'doesNotEqual':
+            if (objectAttribute === queryAttribute.value) return {
+              v: false
+            };
+            break;
+          case 'isGreaterThan':
+            if (!objectAttribute || objectAttribute <= queryAttribute.value) return {
+              v: false
+            };
+            break;
+          case 'isGreaterThanOrEqualTo':
+            if (!objectAttribute || objectAttribute < queryAttribute.value) return {
+              v: false
+            };
+            break;
+          case 'isLessThan':
+            if (!objectAttribute || objectAttribute >= queryAttribute.value) return {
+              v: false
+            };
+            break;
+          case 'isLessThanOrEqualTo':
+            if (!objectAttribute || objectAttribute > queryAttribute.value) return {
+              v: false
+            };
+            break;
+          case 'isBetween':
+            if (!_underscore["default"].isArray(queryAttribute.value) || queryAttribute.value.length !== 2) {
+              throw new Error('Value supplied for isBetween comparator must be an array [ min, max ]');
+            }
+            if (!objectAttribute || objectAttribute < queryAttribute.value[0] || objectAttribute > queryAttribute.value[1]) return {
+              v: false
+            };
+            break;
+          case 'startsWith':
+            if (!objectAttribute) return {
+              v: false
+            };
+            // eslint-disable-next-line max-len
+            if (!_underscore["default"].isString(objectAttribute) || !_underscore["default"].isString(queryAttribute.value)) throw new Error('For startsWith comparator both the object attribute and the query value must be strings.');
+            if (!_startsWith(objectAttribute, queryAttribute.value)) return {
+              v: false
+            };
+            break;
+          case 'endsWith':
+            if (!objectAttribute) return {
+              v: false
+            };
+            // eslint-disable-next-line max-len
+            if (!_underscore["default"].isString(objectAttribute) || !_underscore["default"].isString(queryAttribute.value)) throw new Error('For endsWith comparator both the object attribute and the query value must be strings.');
+            if (!_endsWith(objectAttribute, queryAttribute.value)) return {
+              v: false
+            };
+            break;
+          case 'isNull':
+            if (!_underscore["default"].isNull(objectAttribute)) return {
+              v: false
+            };
+            break;
+          case 'isNotNull':
+            if (_underscore["default"].isNull(objectAttribute)) return {
+              v: false
+            };
+            break;
+          case 'contains':
+            if (!objectAttribute) return {
+              v: false
+            };
+            if (_underscore["default"].isString(objectAttribute)) {
+              return {
+                v: objectAttribute.includes(queryAttribute.value)
+              };
+            } else if (_underscore["default"].isArray(objectAttribute)) {
+              return {
+                v: objectAttribute.some(function (value) {
+                  return _underscore["default"].isEqual(value, queryAttribute.value);
+                })
+              };
+            } else {
+              return {
+                v: false
+              };
+            }
+          default:
+            throw new Error('Invalid comparator ' + queryAttribute.comparator);
+        }
+      } else if (_underscore["default"].isArray(queryAttribute)) {
+        if (!_underscore["default"].contains(queryAttribute, objectAttribute)) return {
+          v: false
+        };
+      } else {
+        if (queryAttribute !== objectAttribute) return {
+          v: false
+        };
       }
-    } else if (_underscore["default"].isArray(queryAttribute)) {
-      if (!_underscore["default"].contains(queryAttribute, objectAttribute)) return false;
-    } else {
-      if (queryAttribute !== objectAttribute) return false;
-    }
+    },
+    _ret;
+  for (var attributeName in whereQuery) {
+    _ret = _loop();
+    if (_ret) return _ret.v;
   }
   return true;
 };

--- a/lib/matchesWhereQuery.js
+++ b/lib/matchesWhereQuery.js
@@ -1,113 +1,66 @@
 "use strict";
 
 var _underscore = _interopRequireDefault(require("underscore"));
-function _interopRequireDefault(e) { return e && e.__esModule ? e : { "default": e }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 module.exports = function (object, whereQuery) {
-  var _loop = function _loop() {
-      var queryAttribute = whereQuery[attributeName];
-      var objectAttribute = object[attributeName];
-      if (_underscore["default"].isObject(queryAttribute) && queryAttribute.comparator) {
-        if (_underscore["default"].isUndefined(queryAttribute.value) && !['isNull', 'isNotNull'].includes(queryAttribute.comparator)) throw new Error('Value must be supplied for comparator queries');
-        switch (queryAttribute.comparator) {
-          case 'doesNotEqual':
-            if (objectAttribute === queryAttribute.value) return {
-              v: false
-            };
-            break;
-          case 'isGreaterThan':
-            if (!objectAttribute || objectAttribute <= queryAttribute.value) return {
-              v: false
-            };
-            break;
-          case 'isGreaterThanOrEqualTo':
-            if (!objectAttribute || objectAttribute < queryAttribute.value) return {
-              v: false
-            };
-            break;
-          case 'isLessThan':
-            if (!objectAttribute || objectAttribute >= queryAttribute.value) return {
-              v: false
-            };
-            break;
-          case 'isLessThanOrEqualTo':
-            if (!objectAttribute || objectAttribute > queryAttribute.value) return {
-              v: false
-            };
-            break;
-          case 'isBetween':
-            if (!_underscore["default"].isArray(queryAttribute.value) || queryAttribute.value.length !== 2) {
-              throw new Error('Value supplied for isBetween comparator must be an array [ min, max ]');
-            }
-            if (!objectAttribute || objectAttribute < queryAttribute.value[0] || objectAttribute > queryAttribute.value[1]) return {
-              v: false
-            };
-            break;
-          case 'startsWith':
-            if (!objectAttribute) return {
-              v: false
-            };
-            // eslint-disable-next-line max-len
-            if (!_underscore["default"].isString(objectAttribute) || !_underscore["default"].isString(queryAttribute.value)) throw new Error('For startsWith comparator both the object attribute and the query value must be strings.');
-            if (!_startsWith(objectAttribute, queryAttribute.value)) return {
-              v: false
-            };
-            break;
-          case 'endsWith':
-            if (!objectAttribute) return {
-              v: false
-            };
-            // eslint-disable-next-line max-len
-            if (!_underscore["default"].isString(objectAttribute) || !_underscore["default"].isString(queryAttribute.value)) throw new Error('For endsWith comparator both the object attribute and the query value must be strings.');
-            if (!_endsWith(objectAttribute, queryAttribute.value)) return {
-              v: false
-            };
-            break;
-          case 'isNull':
-            if (!_underscore["default"].isNull(objectAttribute)) return {
-              v: false
-            };
-            break;
-          case 'isNotNull':
-            if (_underscore["default"].isNull(objectAttribute)) return {
-              v: false
-            };
-            break;
-          case 'contains':
-            if (!objectAttribute) return {
-              v: false
-            };
-            if (_underscore["default"].isString(objectAttribute)) {
-              return {
-                v: objectAttribute.includes(queryAttribute.value)
-              };
-            } else if (_underscore["default"].isArray(objectAttribute)) {
-              return {
-                v: objectAttribute.some(function (value) {
-                  return _underscore["default"].isEqual(value, queryAttribute.value);
-                })
-              };
-            } else {
-              return {
-                v: false
-              };
-            }
-          default:
-            throw new Error('Invalid comparator ' + queryAttribute.comparator);
-        }
-      } else if (_underscore["default"].isArray(queryAttribute)) {
-        if (!_underscore["default"].contains(queryAttribute, objectAttribute)) return {
-          v: false
-        };
-      } else {
-        if (queryAttribute !== objectAttribute) return {
-          v: false
-        };
-      }
-    },
-    _ret;
   for (var attributeName in whereQuery) {
-    _ret = _loop();
-    if (_ret) return _ret.v;
+    var queryAttribute = whereQuery[attributeName];
+    var objectAttribute = object[attributeName];
+    if (_underscore["default"].isObject(queryAttribute) && queryAttribute.comparator) {
+      if (_underscore["default"].isUndefined(queryAttribute.value) && !['isNull', 'isNotNull'].includes(queryAttribute.comparator)) throw new Error('Value must be supplied for comparator queries');
+      switch (queryAttribute.comparator) {
+        case 'doesNotEqual':
+          if (objectAttribute === queryAttribute.value) return false;
+          break;
+        case 'isGreaterThan':
+          if (objectAttribute <= queryAttribute.value) return false;
+          break;
+        case 'isGreaterThanOrEqualTo':
+          if (objectAttribute < queryAttribute.value) return false;
+          break;
+        case 'isLessThan':
+          if (objectAttribute >= queryAttribute.value) return false;
+          break;
+        case 'isLessThanOrEqualTo':
+          if (objectAttribute > queryAttribute.value) return false;
+          break;
+        case 'isBetween':
+          if (!_underscore["default"].isArray(queryAttribute.value) || queryAttribute.value.length !== 2) {
+            throw new Error('Value supplied for isBetween comparator must be an array [ min, max ]');
+          }
+          if (objectAttribute < queryAttribute.value[0] || objectAttribute > queryAttribute.value[1]) return false;
+          break;
+        case 'startsWith':
+          if (!objectAttribute) return false;
+          // eslint-disable-next-line max-len
+          if (!_underscore["default"].isString(objectAttribute) || !_underscore["default"].isString(queryAttribute.value)) throw new Error('For startsWith comparator both the object attribute and the query value must be strings.');
+          if (!_startsWith(objectAttribute, queryAttribute.value)) return false;
+          break;
+        case 'endsWith':
+          if (!objectAttribute) return false;
+          // eslint-disable-next-line max-len
+          if (!_underscore["default"].isString(objectAttribute) || !_underscore["default"].isString(queryAttribute.value)) throw new Error('For endsWith comparator both the object attribute and the query value must be strings.');
+          if (!_endsWith(objectAttribute, queryAttribute.value)) return false;
+          break;
+        case 'isNull':
+          if (!_underscore["default"].isNull(objectAttribute)) return false;
+          break;
+        case 'isNotNull':
+          if (_underscore["default"].isNull(objectAttribute)) return false;
+          break;
+        case 'contains':
+          if (!objectAttribute) return false;
+          if (!_underscore["default"].isString(objectAttribute) && !_underscore["default"].isArray(objectAttribute)) return false;
+          if (!objectAttribute.includes(queryAttribute.value)) return false;
+          break;
+        default:
+          throw new Error('Invalid comparator ' + queryAttribute.comparator);
+      }
+    } else if (_underscore["default"].isArray(queryAttribute)) {
+      if (!_underscore["default"].contains(queryAttribute, objectAttribute)) return false;
+    } else {
+      if (queryAttribute !== objectAttribute) return false;
+    }
   }
   return true;
 };

--- a/src/matchesWhereQuery.es
+++ b/src/matchesWhereQuery.es
@@ -50,9 +50,9 @@ module.exports = function( object, whereQuery ) {
 				break;
 			case 'contains':
 				if( ! objectAttribute ) return false;
-				if ( _.isString( objectAttribute ) ) {
+				if( _.isString( objectAttribute ) ) {
 					return objectAttribute.includes( queryAttribute.value );
-				} else if ( _.isArray( objectAttribute ) ) {
+				} else if( _.isArray( objectAttribute ) ) {
 					return objectAttribute.some( value => _.isEqual( value, queryAttribute.value ) );
 				} else {
 					return false;

--- a/src/matchesWhereQuery.es
+++ b/src/matchesWhereQuery.es
@@ -50,9 +50,13 @@ module.exports = function( object, whereQuery ) {
 				break;
 			case 'contains':
 				if( ! objectAttribute ) return false;
-				if( ! _.isString( objectAttribute ) && ! _.isArray( objectAttribute ) ) return false;
-				if( ! objectAttribute.includes( queryAttribute.value ) ) return false;
-				break;
+				if ( _.isString( objectAttribute ) ) {
+					return objectAttribute.includes( queryAttribute.value );
+				} else if ( _.isArray( objectAttribute ) ) {
+					return objectAttribute.some( value => _.isEqual( value, queryAttribute.value ) );
+				} else {
+					return false;
+				}
 			default:
 				throw new Error ( 'Invalid comparator ' + queryAttribute.comparator );
 			}

--- a/tests/test.js
+++ b/tests/test.js
@@ -3,9 +3,21 @@ var matchesWhereQuery = require( '../lib/matchesWhereQuery' );
 var expect = chai.expect;
 
 describe( 'Matches where query Test', function() {
+	var folder;
 	var person;
 
 	beforeEach( function() {
+		folder = {
+			childrenElements : [
+				{ id : 1, type : 'folder' },
+				{ id : 2, type : 'opportunity' }
+			],
+			miscArray : [
+				[ 1, 2, 3 ],
+				[ 4, 5, 6 ]
+			]
+		};
+
 		person = {
 			firstName : 'Martin',
 			lastName : 'Flores',
@@ -236,28 +248,52 @@ describe( 'Matches where query Test', function() {
 	} );
 
 	describe( 'contains', function() {
-		it( 'Match - when string', function() {
+		it( 'Match - when attribute is string', function() {
 			var comparator = { firstName : { comparator : 'contains', value : 'ar' } };
 
 			expect( matchesWhereQuery( person, comparator ) ).to.be.true;
 		} );
 
-		it( 'Not Match - when string', function() {
+		it( 'Not Match - when attribute is string', function() {
 			var comparator = { firstName : { comparator : 'contains', value : 'no' } };
 
 			expect( matchesWhereQuery( person, comparator ) ).to.be.false;
 		} );
 
-		it( 'Match - when array', function() {
+		it( 'Match - when attribute is array and value is string', function() {
 			var comparator = { permissions : { comparator : 'contains', value : 'read' } };
 
 			expect( matchesWhereQuery( person, comparator ) ).to.be.true;
 		} );
 
-		it( 'Not Match - when array', function() {
+		it( 'Match - when attribute is array and value is array', function() {
+			var comparator = { miscArray : { comparator : 'contains', value : [ 4, 5, 6 ] } };
+
+			expect( matchesWhereQuery( folder, comparator ) ).to.be.true;
+		} );
+
+		it( 'Match - when attribute is array and value is object', function() {
+			var comparator = { childrenElements : { comparator : 'contains', value : { id : 1, type : 'folder' } } };
+
+			expect( matchesWhereQuery( folder, comparator ) ).to.be.true;
+		} );
+
+		it( 'Not Match - when attribute is array and value is string', function() {
 			var comparator = { permissions : { comparator : 'contains', value : 'delete' } };
 
 			expect( matchesWhereQuery( person, comparator ) ).to.be.false;
+		} );
+
+		it( 'Not Match - when attribute is array and value is array', function() {
+			var comparator = { miscArray : { comparator : 'contains', value : [ 7, 8, 9 ] } };
+
+			expect( matchesWhereQuery( folder, comparator ) ).to.be.false;
+		} );
+
+		it( 'Not Match - when attribute is array and value is object', function() {
+			var comparator = { childrenElements : { comparator : 'contains', value : { id : 3, type : 'folder' } } };
+
+			expect( matchesWhereQuery( folder, comparator ) ).to.be.false;
 		} );
 	} );
 } );

--- a/tests/test.js
+++ b/tests/test.js
@@ -248,13 +248,13 @@ describe( 'Matches where query Test', function() {
 	} );
 
 	describe( 'contains', function() {
-		it( 'Match - when attribute is string', function() {
+		it( 'Match - when attribute is string and value is string', function() {
 			var comparator = { firstName : { comparator : 'contains', value : 'ar' } };
 
 			expect( matchesWhereQuery( person, comparator ) ).to.be.true;
 		} );
 
-		it( 'Not Match - when attribute is string', function() {
+		it( 'Not Match - when attribute is string and value is string', function() {
 			var comparator = { firstName : { comparator : 'contains', value : 'no' } };
 
 			expect( matchesWhereQuery( person, comparator ) ).to.be.false;

--- a/tests/test.js
+++ b/tests/test.js
@@ -254,12 +254,6 @@ describe( 'Matches where query Test', function() {
 			expect( matchesWhereQuery( person, comparator ) ).to.be.true;
 		} );
 
-		it( 'Not Match - when attribute is string and value is string', function() {
-			var comparator = { firstName : { comparator : 'contains', value : 'no' } };
-
-			expect( matchesWhereQuery( person, comparator ) ).to.be.false;
-		} );
-
 		it( 'Match - when attribute is array and value is string', function() {
 			var comparator = { permissions : { comparator : 'contains', value : 'read' } };
 
@@ -276,6 +270,12 @@ describe( 'Matches where query Test', function() {
 			var comparator = { childrenElements : { comparator : 'contains', value : { id : 1, type : 'folder' } } };
 
 			expect( matchesWhereQuery( folder, comparator ) ).to.be.true;
+		} );
+
+		it( 'Not Match - when attribute is string and value is string', function() {
+			var comparator = { firstName : { comparator : 'contains', value : 'no' } };
+
+			expect( matchesWhereQuery( person, comparator ) ).to.be.false;
 		} );
 
 		it( 'Not Match - when attribute is array and value is string', function() {


### PR DESCRIPTION
@nico-ledesma @JonaC22 I changed the `contains` comparator so that it compares by equivalence instead of by reference. So far we couldn't use it when the attribute was an array of objects or an array of arrays.

```
// Folder Object has a childrenElements attribute which is an array of objects.

const itemToFind = { id: 1, type: 'folder' };

baseline.folder.where({ childrenElements : { comparator : 'contains', itemToFind } })

// before it didn't return the expected item because { id: 1, type: 'folder' } != { id: 1, type: 'folder' } (different instances, different reference)
// now it returns the expected item because they are equivalent even though they are different instances
```

Notice I'm not updating the `lib/matchesWhereQuery.js` file, only the source `src/matchesWhereQuery.es`. Let me know if I should build it as part of this PR or is the build only done on publish.